### PR TITLE
added templates for automated backup retention  and multi az

### DIFF
--- a/templates/nuclei/aws/rds/components/rds.go
+++ b/templates/nuclei/aws/rds/components/rds.go
@@ -20,6 +20,10 @@ type RDSInstanceArgs struct {
 	Tags                map[string]string
 	Encryption          bool
 	CreateKey           bool
+	MultiAZ             bool                // New field for Multi-AZ support
+	BackupRetentionPeriod int               // New field for backup retention period
+	BackupWindow        string              // New field for backup window
+	MaintenanceWindow   string              // New field for maintenance window
 }
 
 type RDSInstance struct {
@@ -58,6 +62,10 @@ func NewRDSInstance(ctx *pulumi.Context, name string, args *RDSInstanceArgs, opt
 		VpcSecurityGroupIds: args.VpcSecurityGroupIds,
 		SkipFinalSnapshot:   pulumi.Bool(true),
 		Tags:                pulumi.ToStringMap(args.Tags),
+		MultiAz:             pulumi.Bool(args.MultiAZ),                    // Set Multi-AZ
+		BackupRetentionPeriod: pulumi.Int(args.BackupRetentionPeriod),     // Set backup retention period
+		BackupWindow:        pulumi.String(args.BackupWindow),             // Set backup window
+		MaintenanceWindow:   pulumi.String(args.MaintenanceWindow),        // Set maintenance window
 	}
 
 	// Handle encryption
@@ -72,6 +80,7 @@ func NewRDSInstance(ctx *pulumi.Context, name string, args *RDSInstanceArgs, opt
 				return nil, err
 			}
 			instanceArgs.KmsKeyId = key.Arn
+			rdsInstance.KMSKey = key
 		}
 	}
 

--- a/templates/nuclei/aws/rds/main.go
+++ b/templates/nuclei/aws/rds/main.go
@@ -83,6 +83,11 @@ func main() {
 				"Project":     "cfi-rds",
 				"ManagedBy":   "Pulumi",
 			},
+			// New options for Multi-AZ and backups
+			MultiAZ:               true,
+			BackupRetentionPeriod: 7,
+			BackupWindow:          "03:00-04:00",
+			MaintenanceWindow:     "sun:04:30-sun:05:30",
 		})
 		if err != nil {
 			return err

--- a/templates/nuclei/aws/rds/rds-automated-backups.yaml
+++ b/templates/nuclei/aws/rds/rds-automated-backups.yaml
@@ -1,0 +1,48 @@
+id: rds-automated-backups
+
+info:
+  name: RDS check for Automatic Backups
+  author: jlgore
+  severity: high
+  description: |
+    Verifies that AWS RDS instances have a BackupRetentionPeriod greater than zero. 
+  reference:
+    - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ManagingAutomatedBackups.html
+  tags: cloud,devops,aws,amazon,rds,rds-backups
+
+flow: |
+  code(1)
+  for(let rdsInstance of iterate(template.databases)){
+    set("database", rdsInstance)
+    code(2)
+  }
+
+self-contained: true
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      aws rds describe-db-instances --query 'DBInstances[?TagList[?Key==`Project` && Value==`cfi-rds`]].DBInstanceIdentifier' --output json
+    extractors:
+      - type: json # type of the extractor
+        internal: true
+        name: databases
+        json:
+          - '.[]'
+
+  - engine:
+      - sh
+      - bash
+    source: |
+      aws rds describe-db-instances --query 'DBInstances[?BackupRetentionPeriod>`0`].[DBInstanceIdentifier,BackupRetentionPeriod]' --output json
+    matchers:
+      - type: word
+        words:
+          - 'true'
+
+    extractors:
+      - type: dsl
+        dsl:
+          - '"The RDS instance " + database +" has Automated Backups enabled."'
+# digest: 490a004630440220501c7a5024ca35c12300673a71ac57a66cb4a961f0d1c6b5cef212c406ed68dc022007abce8e14ea49c164207ce2ec32229887a692eb871c2e9f6dc876747251749b:ee75fa6ac4bf0c40d6aff9c2694c7e06

--- a/templates/nuclei/aws/rds/rds-multi-az.yaml
+++ b/templates/nuclei/aws/rds/rds-multi-az.yaml
@@ -1,0 +1,43 @@
+id: rds-automated-backups
+
+info:
+  name: RDS check for Multi AZ Database Instance
+  author: jlgore
+  severity: high
+  description: |
+    Verifies that an RDS Database Instance is Multi-AZ.
+  reference:
+    - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html
+  tags: cloud,devops,aws,amazon,rds,rds-backups, high-avail
+
+flow: |
+  code(1)
+  for(let rdsInstance of iterate(template.databases)){
+    set("database", rdsInstance)
+    code(2)
+  }
+
+self-contained: true
+code:
+  - engine:
+      - sh
+      - bash
+    source: |
+      aws rds describe-db-instances --query 'DBInstances[?TagList[?Key==`Project` && Value==`cfi-rds`]].DBInstanceIdentifier' --output json
+    extractors:
+      - type: json # type of the extractor
+        internal: true
+        name: databases
+        json:
+          - '.[]'
+
+  - engine:
+      - sh
+      - bash
+    source: |
+      aws rds describe-db-instances --db-instance-identifier $database --query 'DBInstances[0].[DBInstanceIdentifier,MultiAZ]' --output json
+    extractors:
+      - type: dsl
+        dsl:
+          - '"The RDS instance " + database +" has Automated Backups enabled."'
+# digest: 4a0a00473045022100b85f5c51e6f518d272ae4d1d0ea98c93da289c9e425dfe54e96551b8dc9818d102205e48633c7c06c6e11024549a7ed5a8ab1f6ef3b5bbf512a883ad35caa8895782:ee75fa6ac4bf0c40d6aff9c2694c7e06


### PR DESCRIPTION
Added the following templates to check if multi-az is enabled on a database and for backup retention time period:

``` 
rds-multi-az.yaml
rds-automated-backups.yaml
```

Updated the RDS pulumi components to support Multi AZ and backup retention period setting.